### PR TITLE
COM-4254: Handle Pending Captures from amazon

### DIFF
--- a/assets/src/amazon/amazonpaysdk.js
+++ b/assets/src/amazon/amazonpaysdk.js
@@ -213,7 +213,8 @@ module.exports = function () {
     amazonAuthorizationId,
     orderDetails,
     authorizationReferenceId,
-    declineCapture
+    declineCapture,
+    pendingCapture
   ) {
     var params = {};
     params.AmazonAuthorizationId = amazonAuthorizationId;
@@ -235,11 +236,20 @@ module.exports = function () {
     if (declineCapture)
       params.SellerCaptureNote =
         '{"SandboxSimulation": {"State":"Declined", "ReasonCode":"AmazonRejected"}}';
-
+    else if(pendingCapture)
+      params.SellerCaptureNote = '{"SandboxSimulation": {"State":"Pending"}}';
+   
     console.log("Requesting AWS Capture", params);
     return executeRequest("Capture", params);
   };
 
+  self.getCaptureDetails = function (amazonCaptureId) {
+    var params = {};
+    params.AmazonCaptureId = amazonCaptureId;  
+
+    return executeRequest("GetCaptureDetails", params);
+  };
+  
   self.cancelOrder = function (orderReferenceId) {
     var params = {};
     params.AmazonOrderReferenceId = orderReferenceId;

--- a/assets/src/amazon/checkout.js
+++ b/assets/src/amazon/checkout.js
@@ -535,8 +535,8 @@ module.exports = function (context, callback) {
     var paymentAction = self.ctx.get.paymentAction();
     var payment = self.ctx.get.payment();
 
-    console.log("Payment Action", paymentAction);
-    console.log("Payment", payment);
+    console.log("Payment Action:", paymentAction.actionName);
+    //console.log("Payment", payment);
     console.log("apiContext", self.ctx.apiContext);
     if (payment.paymentType !== paymentConstants.PAYMENTSETTINGID)
       return self.cb();

--- a/assets/src/amazon/paymenthelper.js
+++ b/assets/src/amazon/paymenthelper.js
@@ -333,9 +333,13 @@ var paymentHelper = (module.exports = {
     var self = this;
     amazonPay.configure(config);
     var declineCapture = false;
-    if (context.configuration && context.configuration.payment)
+    var pendingCapture = false;
+    console.log("Configuration:",context.configuration);
+    if (context.configuration && context.configuration.payment){      
       declineCapture = context.configuration.payment.declineCapture === true;
-
+      pendingCapture = context.configuration.payment.pendingCapture === true;
+    }     
+     
     return helper
       .getOrderDetails(context)
       .then(function (orderDetails) {
@@ -365,7 +369,8 @@ var paymentHelper = (module.exports = {
 
         console.log("Authorized interaction", paymentAuthorizationInteraction);
         if (!paymentAuthorizationInteraction) {
-          console.log("interactions", interactions);
+          console.log("no authorized interaction found");
+          //console.log("interactions", interactions);
           return {
             status: paymentConstants.FAILED,
             responseText:
@@ -374,12 +379,55 @@ var paymentHelper = (module.exports = {
           };
         }
 
+        var capturedInteractionWithPendingState = _.findWhere(interactions, {status: "Failed", gatewayResponseText: "Pending"});
+        if(capturedInteractionWithPendingState){
+          console.log("Found capture interaction with pending status");
+          var amazonCaptureId = capturedInteractionWithPendingState.gatewayTransactionId;
+          return amazonPay
+          .getCaptureDetails(amazonCaptureId)
+          .then(function(captureResponse){
+            var captureDetails = captureResponse.GetCaptureDetailsResponse.GetCaptureDetailsResult.CaptureDetails;
+            //console.log("AWS Capture Details", JSON.stringify(captureDetails));
+            var state = captureDetails.CaptureStatus.State;
+            var status;
+            switch (state) {
+              case "Completed":
+                status = paymentConstants.CAPTURED;
+                break;
+              case "Declined":
+                status = paymentConstants.DECLINED;
+                break;  
+              default:
+                status = paymentConstants.FAILED;
+                break;
+            }
+            var response = {
+              status: status,
+              awsTransactionId: captureDetails.AmazonCaptureId,
+              responseText: "Capture Status: "+state,
+              responseCode: 200,
+              amount: captureDetails.CaptureAmount.Amount,
+            };
+            return response;
+          })
+          .catch(function (err) {
+              console.error("Get Capture Detials Error", err);
+              return {
+                status: paymentConstants.FAILED,
+                responseText: err.message,
+                responseCode: err.code,
+              };
+          });                    
+        }
+       
+
         return amazonPay
           .captureAmount(
             paymentAuthorizationInteraction.gatewayTransactionId,
             orderDetails,
             helper.getUniqueId(),
-            declineCapture
+            declineCapture,
+            pendingCapture
           )
           .then(
             function (captureResult) {


### PR DESCRIPTION
If Capture is in pending state on amazon, the capture payment action on
kibo side is considered a failure and the payment stays in Authorized state
with an interaction added on the payment indicating pending status from amazon.
On the next capture attempt, if the "pending" intercation is present on the payment,
we fetch the capture details (from amazon) to verify if the status is "Completed"
or "Declined". Based on that kibo payment is either captured or declined.